### PR TITLE
Improve user profile

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ActiveRecord::Base
   has_many :rounds
+  has_many :decks, through: :rounds
 
   include BCrypt
 
@@ -11,4 +12,15 @@ class User < ActiveRecord::Base
     @password = Password.create(new_password)
     self.password_hash = @password
   end
+
+  # returns round history by deck
+  def round_history
+    rounds = self.rounds.order(created_at: :desc)
+    memo = Hash.new { |h, k| h[k] = [] }
+    history = rounds.each_with_object(memo) { |round, memo|
+                                              memo[round.deck.name] << round
+                                            }
+    Hash[history.sort]
+  end
+
 end

--- a/app/views/users/show.erb
+++ b/app/views/users/show.erb
@@ -1,11 +1,23 @@
 <div class="container">
 <h2><a href="/decks">Play a new game!</a></h2>
   <h2><%= @user.name %> </h2>
-  <% @user.rounds.each do |round| %>
-    <h4>Deck Name: <%= round.deck.name %></h4>
-    <h4>Date Played: <%= round.created_at %></h4>
-    <h4>Cards in Deck: <%= round.cards.count %></h4>
-    <h4>First Guest Correct: <%= round.answered_first_try %></h4>
-    <h4>Total Guesses: <%= round.total_guesses %></h4>
+  <% @user.round_history.each do |deck_name, rounds| %>
+    <h4><%= deck_name %></h4>
+    <table class="stats table">
+      <tr>
+        <th>Date</th>
+        <th>Cards in Deck</th>
+        <th>First Guess Correct</th>
+        <th>Total Guesses</th>
+      </tr>
+      <% rounds.each do |round| %>
+        <tr>
+          <th><%= round.created_at.localtime.strftime("%B %-d, %Y") %></th>
+          <th><%= round.cards.count %></th>
+          <th><%= round.answered_first_try %></th>
+          <th><%= round.total_guesses %></th>
+        </tr>
+      <% end %>
+    </table>
   <% end %>
 </div>


### PR DESCRIPTION
This improves the user profile page to display stats per the original specs and mockups.

I added a round_history method to the User class that returns a hash organized by deck name.  Each key has a value array with all Round objects for that Deck (sorted chronologically descending).

The revised view displays this information in tables per the mockup.  They will still be ugly until we get some layout. :smile:
