### PR TITLE
Add start round button to /decks/:deck_id page

### DIFF
--- a/app/controllers/decks.rb
+++ b/app/controllers/decks.rb
@@ -20,9 +20,7 @@ post '/decks' do
 end
 
 get '/decks/:deck_id' do
-  user = User.find_by(id: session[:user_id])
   @deck = Deck.find_by(id: params[:deck_id])
-  @round = Round.find_or_create_by(user_id: user.id, deck_id: @deck.id)
   @cards = @deck.cards.all
   erb :'/decks/show'
 end

--- a/app/views/decks/show.erb
+++ b/app/views/decks/show.erb
@@ -15,5 +15,8 @@
 </div>
 
 <div id='play'>
-  <a href="/rounds/<%=@round.id%>/card">Play Deck!</a>
+  <form method="post" action="/rounds">
+    <input type="hidden" name="deck_id" value=<%= @deck.id %> />
+    <input type="submit" value="<%= "Play '#{@deck.name}'" %>" />
+  </form>
 </div>


### PR DESCRIPTION
Since rounds are now initiated with POST /rounds (with a deck_id parameter), I added a button (instead of a link) to the dekcs/show view.

I also edited the /decks/:deck_id controller route to eliminate unnecessary variables.

Note that I have verified that the POST '/rounds' route behaves as expected (including redirect to previous page if deck_id is invalid.

FYI, if a view has a Deck instance available, you can add a start game button as I did:

  <form method="post" action="/rounds">
    <input type="hidden" name="deck_id" value=<%= @deck.id %> />
    <input type="submit" value="<%= "Play '#{@deck.name}'" %>" />
  </form>

NOTE: Those multiple quotes around the submit button value appear to be required.  It did not work correctly without them.

In the alternative, if a complete Deck collection (@decks = Deck.all) is available in the view, you could use a select form element in place of the hidden element above:

 `<form method="post" action="/rounds">
    <select name="deck_id>
      <% @decks.each do |deck| %>
        <option value=<%= deck.id %>><%= deck.name %></option>
      <% end %>
    </select> 
    <input type="submit" value="Play" />
  </form>`
